### PR TITLE
Update README to include prerequisites for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,27 @@
 "Snake" is a game that was preloaded on Nokia phones in 1997. A single player controls a square, which continually grows as it moves, resembling a snake. The objective of the game is to get the snake to eat items (by running into food objects) without running into the border of the screen, any obstacles, or itself. 
 
 ## Prerequisites
-* [pip](https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py)
+* Ensure you can run Python 3 from the command line. You can check this by running:
+
+```
+python3 --version
+```
+
+If you do not have Python 3 installed, go here: [Download the latest version of Python](https://www.python.org/downloads/)
+
+* Ensure you can run pip from the command line. You can check this by running:
+
+```
+pip3 --version
+```
+
+If you do not have pip installed, go here: [Installing pip with get-pip.py](https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py)
+
+* Ensure pip, setuptools, and wheel are up to date by running:
+
+```
+python3 -m pip install --upgrade pip setuptools wheel
+```
 
 ## Install & Run
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ python -m pip install --upgrade pip setuptools wheel
 ```
 
 **Windows:**
+
 In addition to the above requirements, please install the following curses package for Windows:
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Ensure you can run Python 3 from the command line. You can check this by running:
 
 ```
-python3 --version
+python --version
 ```
 
 If you do not have Python 3 installed, go here: [Download the latest version of Python](https://www.python.org/downloads/)
@@ -17,7 +17,7 @@ If you do not have Python 3 installed, go here: [Download the latest version of 
 * Ensure you can run pip from the command line. You can check this by running:
 
 ```
-pip3 --version
+pip --version
 ```
 
 If you do not have pip installed, go here: [Installing pip with get-pip.py](https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py)
@@ -25,19 +25,28 @@ If you do not have pip installed, go here: [Installing pip with get-pip.py](http
 * Ensure pip, setuptools, and wheel are up to date by running:
 
 ```
-python3 -m pip install --upgrade pip setuptools wheel
+python -m pip install --upgrade pip setuptools wheel
 ```
+
+**Windows:**
+In addition to the above requirements, please install the following curses package for Windows:
+
+```
+python -m pip install windows-curses
+```
+
+For more information, you can read the documentation for [windows-curses 2.0](https://pypi.org/project/windows-curses/).
 
 ## Install & Run
 
 ```sh
-$ pip3 install open-ouroboros
-$ ouroboros                     # Run the game
+pip3 install open-ouroboros
+ouroboros                     # Run the game
 ```
 
 **Upgrade:**
 ```sh
-$ pip3 install --upgrade open-ouroboros
+pip3 install --upgrade open-ouroboros
 ```
 
 ## Play

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ For more information, you can read the documentation for [windows-curses 2.0](ht
 ## Install & Run
 
 ```sh
-pip3 install open-ouroboros
-ouroboros                     # Run the game
+$ pip3 install open-ouroboros
+$ ouroboros                     # Run the game
 ```
 
 **Upgrade:**
 ```sh
-pip3 install --upgrade open-ouroboros
+$ pip3 install --upgrade open-ouroboros
 ```
 
 ## Play


### PR DESCRIPTION
## Overview
Adds the prerequisites to install the package correctly using `pip`. Includes a note for Windows users to install `windows-curses` in order for the curses module to work. 